### PR TITLE
Add schedule monitor to forger

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",
         "opensearch-project/opensearch-php": "^2.4",
-        "spatie/laravel-menu": "^4.2"
+        "spatie/laravel-menu": "^4.2",
+        "spatie/laravel-schedule-monitor": "^3.10"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ae5e0215f19421fa12e384c166d27fbe",
+    "content-hash": "4b5dcf4271b322ffa1a2bb9517c40919",
     "packages": [
         {
             "name": "brick/math",
@@ -2117,6 +2117,62 @@
             "time": "2024-12-08T08:18:47+00:00"
         },
         {
+            "name": "lorisleiva/cron-translator",
+            "version": "v0.4.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lorisleiva/cron-translator.git",
+                "reference": "082e3cd493de13bd5816bfdda484d07bb2326768"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lorisleiva/cron-translator/zipball/082e3cd493de13bd5816bfdda484d07bb2326768",
+                "reference": "082e3cd493de13bd5816bfdda484d07bb2326768",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Lorisleiva\\CronTranslator\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Loris LEIVA",
+                    "email": "loris.leiva@gmail.com",
+                    "homepage": "https://lorisleiva.com"
+                }
+            ],
+            "description": "Makes CRON expressions human-readable",
+            "homepage": "https://github.com/lorisleiva/cron-translator",
+            "keywords": [
+                "cron",
+                "expression",
+                "human"
+            ],
+            "support": {
+                "issues": "https://github.com/lorisleiva/cron-translator/issues",
+                "source": "https://github.com/lorisleiva/cron-translator/tree/v0.4.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/lorisleiva",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-06-23T10:51:20+00:00"
+        },
+        {
             "name": "monolog/monolog",
             "version": "3.9.0",
             "source": {
@@ -3704,6 +3760,146 @@
                 }
             ],
             "time": "2025-02-21T10:35:09+00:00"
+        },
+        {
+            "name": "spatie/laravel-package-tools",
+            "version": "1.92.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-package-tools.git",
+                "reference": "d20b1969f836d210459b78683d85c9cd5c5f508c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-package-tools/zipball/d20b1969f836d210459b78683d85c9cd5c5f508c",
+                "reference": "d20b1969f836d210459b78683d85c9cd5c5f508c",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^9.28|^10.0|^11.0|^12.0",
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.5",
+                "orchestra/testbench": "^7.7|^8.0|^9.0|^10.0",
+                "pestphp/pest": "^1.23|^2.1|^3.1",
+                "phpunit/php-code-coverage": "^9.0|^10.0|^11.0",
+                "phpunit/phpunit": "^9.5.24|^10.5|^11.5",
+                "spatie/pest-plugin-test-time": "^1.1|^2.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\LaravelPackageTools\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Tools for creating Laravel packages",
+            "homepage": "https://github.com/spatie/laravel-package-tools",
+            "keywords": [
+                "laravel-package-tools",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-package-tools/issues",
+                "source": "https://github.com/spatie/laravel-package-tools/tree/1.92.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-04-11T15:27:14+00:00"
+        },
+        {
+            "name": "spatie/laravel-schedule-monitor",
+            "version": "3.10.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-schedule-monitor.git",
+                "reference": "8731755b91d5d724a5bd2c7028e3d0c8c930e8a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-schedule-monitor/zipball/8731755b91d5d724a5bd2c7028e3d0c8c930e8a1",
+                "reference": "8731755b91d5d724a5bd2c7028e3d0c8c930e8a1",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/bus": "^9.0|^10.0|^11.0|^12.0",
+                "lorisleiva/cron-translator": "^0.3.0|^0.4.0",
+                "nesbot/carbon": "^2.63|^3.0",
+                "nunomaduro/termwind": "^1.10.1|^2.0",
+                "php": "^8.1",
+                "spatie/laravel-package-tools": "^1.9"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.4",
+                "ohdearapp/ohdear-php-sdk": "^3.0",
+                "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
+                "pestphp/pest": "^1.20|^2.34|^3.7",
+                "pestphp/pest-plugin-laravel": "^1.2|^2.3|^3.1",
+                "spatie/pest-plugin-snapshots": "^1.1|^2.1",
+                "spatie/phpunit-snapshot-assertions": "^4.2|^5.1",
+                "spatie/test-time": "^1.2"
+            },
+            "suggest": {
+                "ohdearapp/ohdear-php-sdk": "Needed to sync your schedule with Oh Dear"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\ScheduleMonitor\\ScheduleMonitorServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\ScheduleMonitor\\": "src",
+                    "Spatie\\ScheduleMonitor\\Database\\Factories\\": "database/factories"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Monitor scheduled tasks in a Laravel app",
+            "homepage": "https://github.com/spatie/laravel-schedule-monitor",
+            "keywords": [
+                "laravel-schedule-monitor",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-schedule-monitor/issues",
+                "source": "https://github.com/spatie/laravel-schedule-monitor/tree/3.10.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-21T19:56:48+00:00"
         },
         {
             "name": "spatie/macroable",
@@ -8683,12 +8879,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.2"
     },
-    "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
 }

--- a/config/schedule-monitor.php
+++ b/config/schedule-monitor.php
@@ -1,0 +1,95 @@
+<?php
+
+return [
+    /*
+     * The schedule monitor will log each start, finish and failure of all scheduled jobs.
+     * After a while the `monitored_scheduled_task_log_items` might become big.
+     * Here you can specify the amount of days log items should be kept.
+     *
+     * Use Laravel's pruning command to delete old `MonitoredScheduledTaskLogItem` models.
+     * More info: https://laravel.com/docs/11.x/eloquent#pruning-models
+     */
+    'delete_log_items_older_than_days' => 30,
+
+    /*
+     * The date format used for all dates displayed on the output of commands
+     * provided by this package.
+     */
+    'date_format' => 'Y-m-d H:i:s',
+
+    'models' => [
+        /*
+         * The model you want to use as a MonitoredScheduledTask model needs to extend the
+         * `Spatie\ScheduleMonitor\Models\MonitoredScheduledTask` Model.
+         */
+        'monitored_scheduled_task' => Spatie\ScheduleMonitor\Models\MonitoredScheduledTask::class,
+
+        /*
+         * The model you want to use as a MonitoredScheduledTaskLogItem model needs to extend the
+         * `Spatie\ScheduleMonitor\Models\MonitoredScheduledTaskLogItem` Model.
+         */
+        'monitored_scheduled_log_item' => Spatie\ScheduleMonitor\Models\MonitoredScheduledTaskLogItem::class,
+    ],
+
+    /*
+     * Oh Dear can notify you via Mail, Slack, SMS, web hooks, ... when a
+     * scheduled task does not run on time.
+     *
+     * More info: https://ohdear.app/docs/features/cron-job-monitoring
+     */
+    'oh_dear' => [
+        /*
+         * You can generate an API token at the Oh Dear user settings screen
+         *
+         * https://ohdear.app/user/api-tokens
+         */
+        'api_token' => env('OH_DEAR_API_TOKEN', ''),
+
+        /*
+         *  The id of the site you want to sync the schedule with.
+         *
+         * You'll find this id on the settings page of a site at Oh Dear.
+         */
+        'site_id' => env('OH_DEAR_SITE_ID'),
+
+        /*
+         * To keep scheduled jobs as short as possible, Oh Dear will be pinged
+         * via a queued job. Here you can specify the name of the queue you wish to use.
+         */
+        'queue' => env('OH_DEAR_QUEUE'),
+
+        /*
+         * `PingOhDearJob`s will automatically be skipped if they've been queued for
+         * longer than the time configured here.
+         */
+        'retry_job_for_minutes' => 10,
+
+        /*
+         * When set to true, we will automatically add the `PingOhDearJob` to Horizon's
+         * silenced jobs.
+         */
+        'silence_ping_oh_dear_job_in_horizon' => true,
+
+        /*
+         * Send the start of a scheduled job to Oh Dear. This is not needed
+         * for notifications to work correctly.
+         */
+        'send_starting_ping' => env('OH_DEAR_SEND_STARTING_PING', false),
+
+        /**
+         * The amount of minutes a scheduled task is allowed to run before it is
+         * considered late.
+         */
+        'grace_time_in_minutes' => 5,
+
+        /**
+         * Which endpoint to ping on Oh Dear.
+         */
+        'endpoint_url' => env('OH_DEAR_PING_ENDPOINT_URL'),
+
+        /**
+         * The URL of the Oh Dear API.
+         */
+        'api_url' => env('OH_DEAR_API_URL', 'https://ohdear.app/api/'),
+    ],
+];

--- a/database/migrations/2025_05_26_072056_create_sessions_table.php
+++ b/database/migrations/2025_05_26_072056_create_sessions_table.php
@@ -11,14 +11,16 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('sessions', function (Blueprint $table) {
-            $table->string('id')->primary();
-            $table->foreignId('user_id')->nullable()->index();
-            $table->string('ip_address', 45)->nullable();
-            $table->text('user_agent')->nullable();
-            $table->longText('payload');
-            $table->integer('last_activity')->index();
-        });
+        if (!Schema::hasTable('sessions')) {
+            Schema::create('sessions', function (Blueprint $table) {
+                $table->string('id')->primary();
+                $table->foreignId('user_id')->nullable()->index();
+                $table->string('ip_address', 45)->nullable();
+                $table->text('user_agent')->nullable();
+                $table->longText('payload');
+                $table->integer('last_activity')->index();
+            });
+        }
     }
 
     /**

--- a/database/migrations/2025_07_06_120536_create_schedule_monitor_tables.php
+++ b/database/migrations/2025_07_06_120536_create_schedule_monitor_tables.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateScheduleMonitorTables extends Migration
+{
+    public function up()
+    {
+        Schema::create('monitored_scheduled_tasks', function (Blueprint $table) {
+            $table->bigIncrements('id');
+
+            $table->string('name');
+            $table->string('type')->nullable();
+            $table->string('cron_expression');
+            $table->string('timezone')->nullable();
+            $table->string('ping_url')->nullable();
+
+            $table->dateTime('last_started_at')->nullable();
+            $table->dateTime('last_finished_at')->nullable();
+            $table->dateTime('last_failed_at')->nullable();
+            $table->dateTime('last_skipped_at')->nullable();
+
+            $table->dateTime('registered_on_oh_dear_at')->nullable();
+            $table->dateTime('last_pinged_at')->nullable();
+            $table->integer('grace_time_in_minutes');
+
+            $table->timestamps();
+        });
+
+
+        Schema::create('monitored_scheduled_task_log_items', function (Blueprint $table) {
+            $table->bigIncrements('id');
+
+            $table->unsignedBigInteger('monitored_scheduled_task_id');
+            $table
+                ->foreign('monitored_scheduled_task_id', 'fk_scheduled_task_id')
+                ->references('id')
+                ->on('monitored_scheduled_tasks')
+                ->cascadeOnDelete();
+
+            $table->string('type');
+
+            $table->json('meta')->nullable();
+
+            $table->timestamps();
+        });
+    }
+}

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -49,6 +49,8 @@ tasks:
     - artisan:up
     - deploy:symlink
     - jetrails:reload:php-fpm
+    - artisan:schedule-monitor:sync
+    - varnish:purge
 
   artifact:create:
     - run_locally: 'tar --exclude=".idea" --exclude=".vscode" --exclude=".secrets" --exclude=".git" --exclude=".ddev" --exclude=".env" --exclude=".env.example" --exclude=".env.deploy" --exclude="node_modules" --exclude="storage/logs/*" --exclude="storage/framework/cache/*" --exclude="storage/framework/sessions/*" --exclude="storage/framework/views/*" --exclude=".gitignore" --exclude=".gitattributes" --exclude="README.md" --exclude="phpunit.xml" --exclude="tests" -czf /tmp/{{application}}-{{release_name}}.tar.gz .'
@@ -60,6 +62,9 @@ tasks:
 
   artifact:extract:
     - run: 'cd {{release_path}} && tar -xzf {{application}}-{{release_name}}.tar.gz && rm {{application}}-{{release_name}}.tar.gz'
+
+  artisan:schedule-monitor:sync:
+    - run: '{{bin/php}} {{release_path}}/artisan schedule-monitor:sync'
 
   env:create:
     - run_locally: |
@@ -84,6 +89,9 @@ tasks:
 
   jetrails:reload:php-fpm:
     - run: 'jrctl service restart php-fpm-{{php_fpm_version}}'
+
+  varnish:purge:
+    - run: 'curl -X PURGE -H "JetRails-Purge-Type: all" http://127.0.0.1:6081/'
 
 after:
   deploy:failed: deploy:unlock

--- a/routes/console.php
+++ b/routes/console.php
@@ -5,6 +5,8 @@ use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Schedule;
 use App\Console\Commands\SyncGitHubPRs;
 
+Schedule::command('model:prune')->daily();
+
 Schedule::command(SyncGitHubPRs::class, ['--since' => '1 day ago'])
     ->everyTwoHours()
     ->withoutOverlapping()


### PR DESCRIPTION
Allows you to use `artisan schedule-monitor:list` on the server to check the health of events. 

Also additionally added varnish flush to deployment process