### PR TITLE
[BUGFIX] Use PR index when listing PRs

### DIFF
--- a/app/Http/Controllers/PrsByMonthController.php
+++ b/app/Http/Controllers/PrsByMonthController.php
@@ -13,7 +13,7 @@ class PrsByMonthController extends Controller
     {
         $dataToDisplay = [];
         $params = [
-            'index' => OpenSearchService::getIndexWithPrefix(OpenSearchService::OPENSEARCH_GITHUB_ISSUES_INDEX),
+            'index' => OpenSearchService::getIndexWithPrefix(OpenSearchService::OPENSEARCH_GITHUB_PULL_REQUESTS_INDEX),
             'body'  => [
                 'size' => 0,
                 'query' => [


### PR DESCRIPTION
Forger used the index for issues instead of pullrequests when aggregating data.
By changing the constant to PRs all data is aggregated towards the correct data again.

Fixes #18 