### PR TITLE
Add active flag to maintainer roster and badge inactive members on le…

### DIFF
--- a/app/Console/Commands/SyncGitHubTeams.php
+++ b/app/Console/Commands/SyncGitHubTeams.php
@@ -57,8 +57,8 @@ class SyncGitHubTeams extends Command implements Isolatable
                     continue;
                 }
 
-                $this->persistRoster($role, $logins);
-                $this->info("{$role}: ".count($logins).' members synced (hard-coded list).');
+                $deactivated = $this->reconcileTeamRoster($role, $logins);
+                $this->info("{$role}: ".count($logins)." active, {$deactivated} marked inactive (hard-coded list).");
 
                 continue;
             }
@@ -97,33 +97,7 @@ class SyncGitHubTeams extends Command implements Isolatable
     }
 
     /**
-     * Replace the stored roster for a role with the given logins, all active.
-     * Used for authoritative hard-coded lists.
-     *
-     * @param  list<string>  $logins
-     */
-    private function persistRoster(string $role, array $logins): void
-    {
-        DB::transaction(function () use ($role, $logins): void {
-            RoleEligibility::query()->where('role', $role)->delete();
-
-            foreach (array_chunk($logins, 500) as $chunk) {
-                RoleEligibility::query()->insert(array_map(
-                    fn (string $login): array => [
-                        'login' => $login,
-                        'role' => $role,
-                        'active' => true,
-                        'created_at' => now(),
-                        'updated_at' => now(),
-                    ],
-                    $chunk,
-                ));
-            }
-        });
-    }
-
-    /**
-     * Reconcile a role against the current GitHub team roster without deleting.
+     * Reconcile a role against the current roster without deleting.
      * Everyone on the team is (re)activated; anyone previously eligible but no
      * longer on the team is retained and marked inactive. Returns the number of
      * members newly marked inactive.

--- a/app/Console/Commands/SyncGitHubTeams.php
+++ b/app/Console/Commands/SyncGitHubTeams.php
@@ -10,11 +10,13 @@ namespace App\Console\Commands;
 
 use App\Models\RoleEligibility;
 use App\Services\GitHub\GitHubConnection;
+use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Console\Isolatable;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use JsonException;
 use Throwable;
 
 /**
@@ -38,14 +40,31 @@ class SyncGitHubTeams extends Command implements Isolatable
             return 1;
         }
 
-        $teams = [
-            'maintainer' => (string) config('leaderboard.teams.maintainers'),
-            'community-council' => (string) config('leaderboard.teams.council'),
+        $sources = [
+            'maintainer' => config('leaderboard.teams.maintainers'),
+            'community-council' => config('leaderboard.teams.council'),
         ];
 
         $hadError = false;
 
-        foreach ($teams as $role => $slug) {
+        foreach ($sources as $role => $source) {
+            if (is_array($source)) {
+                $logins = $this->normalizeLogins($source);
+
+                if ($logins === []) {
+                    $this->warn("No members configured for {$role}; skipping.");
+
+                    continue;
+                }
+
+                $this->persistRoster($role, $logins);
+                $this->info("{$role}: ".count($logins).' members synced (hard-coded list).');
+
+                continue;
+            }
+
+            $slug = (string) $source;
+
             if ($slug === '') {
                 $this->warn("No team slug configured for {$role}; skipping.");
 
@@ -62,23 +81,8 @@ class SyncGitHubTeams extends Command implements Isolatable
                 continue;
             }
 
-            DB::transaction(function () use ($role, $logins): void {
-                RoleEligibility::query()->where('role', $role)->delete();
-
-                foreach (array_chunk($logins, 500) as $chunk) {
-                    RoleEligibility::query()->insert(array_map(
-                        fn (string $login): array => [
-                            'login' => $login,
-                            'role' => $role,
-                            'created_at' => now(),
-                            'updated_at' => now(),
-                        ],
-                        $chunk,
-                    ));
-                }
-            });
-
-            $this->info("{$role}: {$slug} → ".count($logins).' members synced.');
+            $deactivated = $this->reconcileTeamRoster($role, $logins);
+            $this->info("{$role}: {$slug} → ".count($logins)." active, {$deactivated} marked inactive.");
         }
 
         if ($hadError) {
@@ -93,7 +97,95 @@ class SyncGitHubTeams extends Command implements Isolatable
     }
 
     /**
+     * Replace the stored roster for a role with the given logins, all active.
+     * Used for authoritative hard-coded lists.
+     *
+     * @param  list<string>  $logins
+     */
+    private function persistRoster(string $role, array $logins): void
+    {
+        DB::transaction(function () use ($role, $logins): void {
+            RoleEligibility::query()->where('role', $role)->delete();
+
+            foreach (array_chunk($logins, 500) as $chunk) {
+                RoleEligibility::query()->insert(array_map(
+                    fn (string $login): array => [
+                        'login' => $login,
+                        'role' => $role,
+                        'active' => true,
+                        'created_at' => now(),
+                        'updated_at' => now(),
+                    ],
+                    $chunk,
+                ));
+            }
+        });
+    }
+
+    /**
+     * Reconcile a role against the current GitHub team roster without deleting.
+     * Everyone on the team is (re)activated; anyone previously eligible but no
+     * longer on the team is retained and marked inactive. Returns the number of
+     * members newly marked inactive.
+     *
+     * @param  list<string>  $logins
+     */
+    private function reconcileTeamRoster(string $role, array $logins): int
+    {
+        return DB::transaction(function () use ($role, $logins): int {
+            $now = now();
+
+            foreach (array_chunk($logins, 500) as $chunk) {
+                RoleEligibility::query()->upsert(
+                    array_map(
+                        fn (string $login): array => [
+                            'login' => $login,
+                            'role' => $role,
+                            'active' => true,
+                            'created_at' => $now,
+                            'updated_at' => $now,
+                        ],
+                        $chunk,
+                    ),
+                    ['login', 'role'],
+                    ['active', 'updated_at'],
+                );
+            }
+
+            return RoleEligibility::query()
+                ->where('role', $role)
+                ->where('active', true)
+                ->when($logins !== [], fn ($query) => $query->whereNotIn('login', $logins))
+                ->update(['active' => false, 'updated_at' => $now]);
+        });
+    }
+
+    /**
+     * Trim, drop blanks, and de-duplicate a hard-coded list of logins.
+     *
+     * @param  array<int|string, mixed>  $logins
      * @return list<string>
+     */
+    private function normalizeLogins(array $logins): array
+    {
+        $clean = [];
+
+        foreach ($logins as $login) {
+            $login = trim((string) $login);
+
+            if ($login !== '') {
+                $clean[] = $login;
+            }
+        }
+
+        return array_values(array_unique($clean));
+    }
+
+    /**
+     * @return list<string>
+     *
+     * @throws GuzzleException
+     * @throws JsonException
      */
     private function fetchMembers(GitHubConnection $connection, string $owner, string $slug): array
     {

--- a/app/Http/Controllers/MaintainerLeaderboardController.php
+++ b/app/Http/Controllers/MaintainerLeaderboardController.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Models\RoleEligibility;
 use App\Queries\Dashboard\ReviewsApprovedLeaderboardQuery;
 use App\Queries\Dashboard\ReviewsRejectedLeaderboardQuery;
 use Carbon\Carbon;
@@ -60,8 +61,26 @@ class MaintainerLeaderboardController extends Controller
             'to' => $to,
             'period' => $period,
             'dataMissing' => $dataMissing,
+            'inactiveLogins' => $this->inactiveMaintainerLogins(),
             'githubUrl' => $this->buildGitHubUrlResolver($metric, $from->toDateString(), $to->toDateString()),
         ]);
+    }
+
+    /**
+     * Logins of maintainers retained in the roster but no longer on the team,
+     * keyed for O(1) lookup in the view.
+     *
+     * @return array<string, true>
+     */
+    private function inactiveMaintainerLogins(): array
+    {
+        return RoleEligibility::query()
+            ->where('role', 'maintainer')
+            ->where('active', false)
+            ->pluck('login')
+            ->flip()
+            ->map(fn (): bool => true)
+            ->all();
     }
 
     /**

--- a/app/Http/Controllers/ScoreLeaderboardController.php
+++ b/app/Http/Controllers/ScoreLeaderboardController.php
@@ -448,7 +448,7 @@ class ScoreLeaderboardController extends Controller
      */
     private function maintainerRows(): Collection
     {
-        $roster = RoleEligibility::query()->where('role', 'maintainer')->pluck('login');
+        $roster = RoleEligibility::query()->where('role', 'maintainer')->get(['login', 'active']);
 
         if ($roster->isEmpty()) {
             return LeaderboardEntry::query()
@@ -464,17 +464,18 @@ class ScoreLeaderboardController extends Controller
         $scores = LeaderboardEntry::query()
             ->where('board', 'maintainer')
             ->where('window', 'rolling12')
-            ->whereIn('login', $roster)
+            ->whereIn('login', $roster->pluck('login'))
             ->get()
             ->keyBy('login');
 
         return $roster
-            ->map(fn (string $login): object => (object) [
-                'login' => $login,
-                'score' => (float) (optional($scores->get($login))->score ?? 0.0),
-                'breakdown' => optional($scores->get($login))->breakdown ?? [],
+            ->map(fn (RoleEligibility $member): object => (object) [
+                'login' => $member->login,
+                'active' => (bool) $member->active,
+                'score' => (float) (optional($scores->get($member->login))->score ?? 0.0),
+                'breakdown' => optional($scores->get($member->login))->breakdown ?? [],
             ])
-            ->sortByDesc('score')
+            ->sortBy([['active', 'desc'], ['score', 'desc']])
             ->values();
     }
 

--- a/config/leaderboard.php
+++ b/config/leaderboard.php
@@ -32,7 +32,7 @@ return [
      * and in-PHP checks. Add a bot here and it applies everywhere.
      */
     'bots' => [
-        'exact' => ['dependabot[bot]', 'github-actions[bot]', 'm2-assistant'],
+        'exact' => ['dependabot[bot]', 'github-actions[bot]', 'm2-assistant', 'magento-github-admin-beta'],
         'prefixes' => ['engcom-', 'magento-automated', 'm2-community', 'github-', 'ct-prd-projects', 'copilot-pull-request-reviewer'],
     ],
 
@@ -125,15 +125,28 @@ return [
     ],
 
     /*
-     * GitHub teams (under the repo owner org) whose members may earn maintainer
-     * points: the maintainer team and the community-council committee (who hold
-     * maintainer rights). Synced by sync:github:teams into role_eligibilities as
-     * roles `maintainer` and `community-council`. Contributor points are open to
-     * everyone. If both rosters are empty, gating is disabled and everyone counts.
+     * Rosters whose members may earn maintainer points: the maintainer team and
+     * the community-council committee (who hold maintainer rights). Synced by
+     * sync:github:teams into role_eligibilities as roles `maintainer` and
+     * `community-council`. Contributor points are open to everyone. If both
+     * rosters are empty, gating is disabled and everyone counts.
+     *
+     * Each entry is either a GitHub team slug (string, fetched from the org) or
+     * a hard-coded list of logins (array). The council has no dedicated GitHub
+     * team — its members are mixed into community-council-ma — so it is listed
+     * explicitly here.
      */
     'teams' => [
         'maintainers' => 'community-council-ma',
-        'council' => 'community-council',
+        'council' => [
+            'lfolco',
+            'sprankhub',
+            'IvanChepurnyi',
+            'jissereitsma',
+            'rhoerr',
+            'furan917',
+            'nithinterrific',
+        ],
     ],
 
     /*

--- a/database/migrations/2026_07_07_165753_add_active_to_role_eligibilities_table.php
+++ b/database/migrations/2026_07_07_165753_add_active_to_role_eligibilities_table.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('role_eligibilities', function (Blueprint $table) {
+            // Maintainers who leave the GitHub team are kept but marked inactive.
+            $table->boolean('active')->default(true)->after('role');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('role_eligibilities', function (Blueprint $table) {
+            $table->dropColumn('active');
+        });
+    }
+};

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -24,6 +24,7 @@
         <env name="CACHE_STORE" value="array"/>
         <env name="DB_CONNECTION" value="sqlite"/>
         <env name="DB_DATABASE" value=":memory:"/>
+        <env name="GITHUB_TOKEN" value="test-token"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/resources/views/leaderboard/maintainer.blade.php
+++ b/resources/views/leaderboard/maintainer.blade.php
@@ -70,6 +70,9 @@
                                     <a href="https://github.com/{{ $contributor->login }}" target="_blank" rel="noopener noreferrer" class="text-decoration-none fw-medium">
                                         {{ $contributor->login }}
                                     </a>
+                                    @isset($inactiveLogins[$contributor->login])
+                                        <span class="badge text-bg-secondary ms-1" title="No longer on the maintainer team">Inactive</span>
+                                    @endisset
                                 </td>
                                 <td class="text-end">
                                     <a href="{{ $githubUrl($contributor->login) }}" target="_blank" rel="noopener noreferrer" class="text-decoration-none">

--- a/resources/views/leaderboard/score.blade.php
+++ b/resources/views/leaderboard/score.blade.php
@@ -46,6 +46,9 @@
                                     @if ($profile?->name)
                                         <span class="text-muted small">{{ '@'.$entry->login }}</span>
                                     @endif
+                                    @if (($entry->active ?? true) === false)
+                                        <span class="badge text-bg-secondary ms-1" title="No longer on the maintainer team">Inactive</span>
+                                    @endif
                                 </td>
                                 <td class="text-end">
                                     @php($breakdownTitle = collect($entry->breakdown)->map(fn ($detail, $action) => e(\App\DataTransferObjects\Leaderboard\Action::labelFor($action)).' &mdash; '.number_format($detail['count'] ?? 0).'&times; &rarr; '.number_format($detail['points'] ?? 0, 1).' pts')->implode('<br>'))

--- a/tests/Feature/Console/Commands/SyncGitHubTeamsTest.php
+++ b/tests/Feature/Console/Commands/SyncGitHubTeamsTest.php
@@ -58,9 +58,9 @@ class SyncGitHubTeamsTest extends TestCase
         $this->assertDatabaseHas('role_eligibilities', ['login' => 'dave', 'role' => 'maintainer', 'active' => false]);  // stays inactive
     }
 
-    public function testHardCodedCouncilListReplacesRoster(): void
+    public function testHardCodedCouncilListActivatesMembersAndRetainsLeaversAsInactive(): void
     {
-        RoleEligibility::create(['login' => 'stale', 'role' => 'community-council']);
+        RoleEligibility::create(['login' => 'stale', 'role' => 'community-council', 'active' => true]);
 
         config([
             'leaderboard.teams.maintainers' => '',
@@ -69,13 +69,14 @@ class SyncGitHubTeamsTest extends TestCase
 
         $this->artisan('sync:github:teams')->assertExitCode(0);
 
-        $this->assertDatabaseHas('role_eligibilities', ['login' => 'ada', 'role' => 'community-council']);
-        $this->assertDatabaseHas('role_eligibilities', ['login' => 'grace', 'role' => 'community-council']);
-        $this->assertDatabaseHas('role_eligibilities', ['login' => 'linus', 'role' => 'community-council']);
-        $this->assertDatabaseMissing('role_eligibilities', ['login' => 'stale']);
+        $this->assertDatabaseHas('role_eligibilities', ['login' => 'ada', 'role' => 'community-council', 'active' => true]);
+        $this->assertDatabaseHas('role_eligibilities', ['login' => 'grace', 'role' => 'community-council', 'active' => true]);
+        $this->assertDatabaseHas('role_eligibilities', ['login' => 'linus', 'role' => 'community-council', 'active' => true]);
+        // Removed member is retained but marked inactive, not deleted.
+        $this->assertDatabaseHas('role_eligibilities', ['login' => 'stale', 'role' => 'community-council', 'active' => false]);
 
-        // Trimmed, de-duplicated, blanks dropped: exactly three rows.
-        $this->assertSame(3, RoleEligibility::where('role', 'community-council')->count());
+        // Trimmed, de-duplicated, blanks dropped: three active members.
+        $this->assertSame(3, RoleEligibility::where('role', 'community-council')->where('active', true)->count());
     }
 
     public function testEmptyHardCodedListLeavesRosterUnchanged(): void

--- a/tests/Feature/Console/Commands/SyncGitHubTeamsTest.php
+++ b/tests/Feature/Console/Commands/SyncGitHubTeamsTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * @copyright Copyright (c) 2026 The Magento Association
+ * @license https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Tests\Feature\Console\Commands;
+
+use App\Models\RoleEligibility;
+use App\Services\GitHub\GitHubConnection;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SyncGitHubTeamsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function testTeamSyncActivatesMembersAndMarksLeaversInactiveWithoutDeleting(): void
+    {
+        // alice already active, erin returning (inactive), carol left the team, dave already inactive.
+        RoleEligibility::create(['login' => 'alice', 'role' => 'maintainer', 'active' => true]);
+        RoleEligibility::create(['login' => 'erin', 'role' => 'maintainer', 'active' => false]);
+        RoleEligibility::create(['login' => 'carol', 'role' => 'maintainer', 'active' => true]);
+        RoleEligibility::create(['login' => 'dave', 'role' => 'maintainer', 'active' => false]);
+
+        config([
+            'github.repo' => 'magento/magento2',
+            'leaderboard.teams.maintainers' => 'the-team',
+            'leaderboard.teams.council' => [],
+        ]);
+
+        // Team roster from GitHub: alice + erin (bob is a brand-new member).
+        $mock = new MockHandler([
+            new Response(200, [], json_encode([
+                ['login' => 'alice'],
+                ['login' => 'erin'],
+                ['login' => 'bob'],
+            ])),
+        ]);
+        $rest = new Client(['handler' => HandlerStack::create($mock)]);
+        $this->app->instance(
+            GitHubConnection::class,
+            new GitHubConnection(graphQlClient: new Client, restClient: $rest),
+        );
+
+        $this->artisan('sync:github:teams')->assertExitCode(0);
+
+        $this->assertDatabaseHas('role_eligibilities', ['login' => 'alice', 'role' => 'maintainer', 'active' => true]);
+        $this->assertDatabaseHas('role_eligibilities', ['login' => 'erin', 'role' => 'maintainer', 'active' => true]);   // reactivated
+        $this->assertDatabaseHas('role_eligibilities', ['login' => 'bob', 'role' => 'maintainer', 'active' => true]);    // newly added
+        $this->assertDatabaseHas('role_eligibilities', ['login' => 'carol', 'role' => 'maintainer', 'active' => false]); // left → inactive, not deleted
+        $this->assertDatabaseHas('role_eligibilities', ['login' => 'dave', 'role' => 'maintainer', 'active' => false]);  // stays inactive
+    }
+
+    public function testHardCodedCouncilListReplacesRoster(): void
+    {
+        RoleEligibility::create(['login' => 'stale', 'role' => 'community-council']);
+
+        config([
+            'leaderboard.teams.maintainers' => '',
+            'leaderboard.teams.council' => ['ada', 'grace ', '', 'ada', 'linus'],
+        ]);
+
+        $this->artisan('sync:github:teams')->assertExitCode(0);
+
+        $this->assertDatabaseHas('role_eligibilities', ['login' => 'ada', 'role' => 'community-council']);
+        $this->assertDatabaseHas('role_eligibilities', ['login' => 'grace', 'role' => 'community-council']);
+        $this->assertDatabaseHas('role_eligibilities', ['login' => 'linus', 'role' => 'community-council']);
+        $this->assertDatabaseMissing('role_eligibilities', ['login' => 'stale']);
+
+        // Trimmed, de-duplicated, blanks dropped: exactly three rows.
+        $this->assertSame(3, RoleEligibility::where('role', 'community-council')->count());
+    }
+
+    public function testEmptyHardCodedListLeavesRosterUnchanged(): void
+    {
+        RoleEligibility::create(['login' => 'keep', 'role' => 'community-council']);
+
+        config([
+            'leaderboard.teams.maintainers' => '',
+            'leaderboard.teams.council' => [],
+        ]);
+
+        $this->artisan('sync:github:teams')->assertExitCode(0);
+
+        $this->assertDatabaseHas('role_eligibilities', ['login' => 'keep', 'role' => 'community-council']);
+    }
+}

--- a/tests/Feature/Http/Controllers/MaintainerLeaderboardControllerTest.php
+++ b/tests/Feature/Http/Controllers/MaintainerLeaderboardControllerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * @copyright Copyright (c) 2026 The Magento Association
  * @license https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
@@ -17,6 +18,12 @@ use Tests\TestCase;
 class MaintainerLeaderboardControllerTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutVite();
+    }
 
     public function testInactiveMaintainerIsBadgedOnTheLeaderboard(): void
     {

--- a/tests/Feature/Http/Controllers/MaintainerLeaderboardControllerTest.php
+++ b/tests/Feature/Http/Controllers/MaintainerLeaderboardControllerTest.php
@@ -1,0 +1,47 @@
+<?php
+/*
+ * @copyright Copyright (c) 2026 The Magento Association
+ * @license https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Tests\Feature\Http\Controllers;
+
+use App\DataTransferObjects\Dashboard\ContributorCount;
+use App\Models\RoleEligibility;
+use App\Queries\Dashboard\ReviewsApprovedLeaderboardQuery;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MaintainerLeaderboardControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function testInactiveMaintainerIsBadgedOnTheLeaderboard(): void
+    {
+        RoleEligibility::create(['login' => 'carol', 'role' => 'maintainer', 'active' => false]);
+        RoleEligibility::create(['login' => 'alice', 'role' => 'maintainer', 'active' => true]);
+
+        $this->app->bind(ReviewsApprovedLeaderboardQuery::class, fn () => new class extends ReviewsApprovedLeaderboardQuery
+        {
+            public function __construct() {}
+
+            public function execute(Carbon $from, Carbon $to): array
+            {
+                return [
+                    new ContributorCount('carol', 5),
+                    new ContributorCount('alice', 3),
+                ];
+            }
+        });
+
+        $response = $this->get(route('maintainer.leaderboard.show', ['metric' => 'reviews-approved']));
+
+        $response->assertOk();
+        $response->assertSeeInOrder(['carol', 'Inactive']);
+        $response->assertSeeText('alice');
+        // Only the inactive maintainer is badged.
+        $this->assertSame(1, substr_count($response->getContent(), '>Inactive<'));
+    }
+}


### PR DESCRIPTION
…aderboard

Adds `active` boolean column to `role_eligibilities` table, defaulting to true. Updates `sync:github:teams` command to mark team leavers as inactive instead of deleting them, while reactivating returning members. Hard-coded council roster replaces GitHub team fetch for community-council role. Inactive maintainers are now badged on leaderboards with "Inactive" label and sorted below active members. Adds `magento-github-admin-beta` to bot exclusion list. Includes feature tests for inactive badging and team sync reconciliation logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Leaderboards now clearly label maintainers who are no longer active with an “Inactive” badge.
  - Inactive maintainers remain visible in results while active contributors are prioritized in rankings.
  - Team synchronization now supports both GitHub-managed teams and configured member lists.

- **Bug Fixes**
  - Team updates preserve historical eligibility records while accurately activating new members and deactivating former members.
  - Council roster configuration now supports cleaned, duplicate-free member lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->