### PR TITLE
Add bootstrap-prod script for one-time 

### DIFF
--- a/app/Console/Commands/SyncGitHubEvents.php
+++ b/app/Console/Commands/SyncGitHubEvents.php
@@ -135,6 +135,6 @@ class SyncGitHubEvents extends Command implements Isolatable
         $this->reportCutoffReached($result, $cutoff, 'issue');
         $this->reportDone($errorOccurred, 'Done syncing GitHub events.');
 
-        return 0;
+        return $errorOccurred ? 1 : 0;
     }
 }

--- a/app/Console/Commands/SyncGitHubInteractions.php
+++ b/app/Console/Commands/SyncGitHubInteractions.php
@@ -136,6 +136,6 @@ class SyncGitHubInteractions extends Command implements Isolatable
         $this->reportCutoffReached($result, $cutoff, 'issue');
         $this->reportDone($errorOccurred, 'Done syncing interactions.');
 
-        return 0;
+        return $errorOccurred ? 1 : 0;
     }
 }

--- a/app/Console/Commands/SyncGitHubIssues.php
+++ b/app/Console/Commands/SyncGitHubIssues.php
@@ -77,6 +77,6 @@ class SyncGitHubIssues extends Command implements Isolatable
         $this->reportCutoffReached($result, $cutoff, 'issue');
         $this->reportDone($errorOccurred, 'Done syncing issues.');
 
-        return 0;
+        return $errorOccurred ? 1 : 0;
     }
 }

--- a/app/Console/Commands/SyncGitHubPRs.php
+++ b/app/Console/Commands/SyncGitHubPRs.php
@@ -80,6 +80,6 @@ class SyncGitHubPRs extends Command implements Isolatable
         $this->reportCutoffReached($result, $cutoff, 'PR');
         $this->reportDone($errorOccurred, 'Done syncing PRs.');
 
-        return 0;
+        return $errorOccurred ? 1 : 0;
     }
 }

--- a/scripts/bootstrap-prod.sh
+++ b/scripts/bootstrap-prod.sh
@@ -26,11 +26,14 @@ fi
 
 # Pick how to reach artisan:
 #   - inside the ddev web container (`ddev bootstrap-prod`) → php artisan
-#   - on a dev host with ddev installed                     → ddev artisan
+#   - on a dev host, in a ddev project, with ddev installed → ddev artisan
 #   - anywhere else (plain server, CI, prod)                → php artisan
+#
+# The ddev binary alone is not enough: a checkout without .ddev/config.yaml has
+# no project for `ddev artisan` to attach to.
 if [ "${IS_DDEV_PROJECT:-}" = "true" ]; then
     ARTISAN=(php artisan)
-elif command -v ddev >/dev/null 2>&1; then
+elif [ -f .ddev/config.yaml ] && command -v ddev >/dev/null 2>&1; then
     ARTISAN=(ddev artisan)
 else
     ARTISAN=(php artisan)

--- a/scripts/bootstrap-prod.sh
+++ b/scripts/bootstrap-prod.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# @copyright Copyright (c) 2026 The Magento Association
+# @license https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+#
+
+# One-time production bootstrap. Populates OpenSearch with the full GitHub
+# history and computes the initial leaderboard scores. Run once after the first
+# deploy of the leaderboard feature; thereafter the scheduler keeps data fresh
+# (see routes/console.php and scripts/sync-week.sh).
+#
+# Unlike sync-week.sh this omits --since, so every sync pulls the full history.
+# That is heavy on the GitHub API. To scope it, set SINCE (e.g. SINCE="1 year")
+# and it is passed to the data syncs that accept it.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Optional history window. Empty (default) = full history.
+#   SINCE="1 year" ./scripts/bootstrap-prod.sh
+SINCE="${SINCE:-}"
+since_args=()
+if [ -n "$SINCE" ]; then
+    since_args=(--since="$SINCE")
+fi
+
+# Pick how to reach artisan:
+#   - inside the ddev web container (`ddev bootstrap-prod`) → php artisan
+#   - on a dev host with ddev installed                     → ddev artisan
+#   - anywhere else (plain server, CI, prod)                → php artisan
+if [ "${IS_DDEV_PROJECT:-}" = "true" ]; then
+    ARTISAN=(php artisan)
+elif command -v ddev >/dev/null 2>&1; then
+    ARTISAN=(ddev artisan)
+else
+    ARTISAN=(php artisan)
+fi
+
+# 1. Maintainer/council roster (source of truth = GitHub teams). Supplement with
+#    leaderboard:import-eligibility if you have roster rows not in GitHub teams.
+echo "==> Syncing GitHub teams (maintainer/council roster)"
+"${ARTISAN[@]}" sync:github:teams
+
+# 2. Full historical data into OpenSearch.
+echo "==> Syncing GitHub issues${SINCE:+ (since: $SINCE)}"
+"${ARTISAN[@]}" sync:github:issues ${since_args[@]+"${since_args[@]}"}
+
+echo "==> Syncing GitHub PRs${SINCE:+ (since: $SINCE)}"
+"${ARTISAN[@]}" sync:github:prs ${since_args[@]+"${since_args[@]}"}
+
+echo "==> Syncing GitHub interactions${SINCE:+ (since: $SINCE)}"
+"${ARTISAN[@]}" sync:github:interactions ${since_args[@]+"${since_args[@]}"}
+
+echo "==> Syncing GitHub events${SINCE:+ (since: $SINCE)}"
+"${ARTISAN[@]}" sync:github:events ${since_args[@]+"${since_args[@]}"}
+
+# 3. Display names + avatars for everyone who appeared above.
+echo "==> Syncing GitHub profiles"
+"${ARTISAN[@]}" sync:github:profiles
+
+# 4. Compute leaderboard scores from the synced data.
+echo "==> Computing leaderboard scores"
+"${ARTISAN[@]}" leaderboard:compute
+
+echo "==> Done"

--- a/scripts/sync-week.sh
+++ b/scripts/sync-week.sh
@@ -20,12 +20,15 @@ else
 fi
 
 # Pick how to reach artisan:
-#   - inside the ddev web container (`ddev sync-week`) → php artisan
-#   - on a dev host with ddev installed              → ddev artisan
-#   - anywhere else (plain server, CI, prod)         → php artisan
+#   - inside the ddev web container (`ddev sync-week`)      → php artisan
+#   - on a dev host, in a ddev project, with ddev installed → ddev artisan
+#   - anywhere else (plain server, CI, prod)                → php artisan
+#
+# The ddev binary alone is not enough: a checkout without .ddev/config.yaml has
+# no project for `ddev artisan` to attach to.
 if [ "${IS_DDEV_PROJECT:-}" = "true" ]; then
     ARTISAN=(php artisan)
-elif command -v ddev >/dev/null 2>&1; then
+elif [ -f .ddev/config.yaml ] && command -v ddev >/dev/null 2>&1; then
     ARTISAN=(ddev artisan)
 else
     ARTISAN=(php artisan)

--- a/tests/Feature/Console/Commands/SyncGitHubEventsTest.php
+++ b/tests/Feature/Console/Commands/SyncGitHubEventsTest.php
@@ -118,7 +118,7 @@ class SyncGitHubEventsTest extends TestCase
             ->expectsOutputToContain('Done syncing GitHub events.');
     }
 
-    public function testPageErrorShowsErrorMessageAndSuppressesDoneMessage(): void
+    public function testPageErrorExitsWithCode1AndSuppressesDoneMessage(): void
     {
         $this->mock(GitHubInteractionService::class);
         $this->mock(GitHubIssueService::class);
@@ -132,7 +132,7 @@ class SyncGitHubEventsTest extends TestCase
             });
 
         $this->artisan('sync:github:events')
-            ->assertExitCode(0)
+            ->assertExitCode(1)
             ->expectsOutputToContain('Page 3 failed: Connection refused')
             ->doesntExpectOutputToContain('Done syncing GitHub events.');
     }
@@ -153,7 +153,7 @@ class SyncGitHubEventsTest extends TestCase
             });
 
         $this->artisan('sync:github:events')
-            ->assertExitCode(0)
+            ->assertExitCode(1)
             ->expectsOutputToContain('Page 2 failed: GitHub GraphQL API error')
             ->expectsOutputToContain('GraphQL error: Could not resolve to a Repository');
     }

--- a/tests/Feature/Console/Commands/SyncGitHubInteractionsTest.php
+++ b/tests/Feature/Console/Commands/SyncGitHubInteractionsTest.php
@@ -110,7 +110,7 @@ class SyncGitHubInteractionsTest extends TestCase
             ->expectsOutputToContain('Done syncing interactions.');
     }
 
-    public function testPageErrorShowsErrorMessageAndSuppressesDoneMessage(): void
+    public function testPageErrorExitsWithCode1AndSuppressesDoneMessage(): void
     {
         $this->mock(GitHubInteractionService::class);
         $this->mock(GitHubIssueService::class);
@@ -124,7 +124,7 @@ class SyncGitHubInteractionsTest extends TestCase
             });
 
         $this->artisan('sync:github:interactions')
-            ->assertExitCode(0)
+            ->assertExitCode(1)
             ->expectsOutputToContain('Page 3 failed: Connection refused')
             ->doesntExpectOutputToContain('Done syncing interactions.');
     }
@@ -145,7 +145,7 @@ class SyncGitHubInteractionsTest extends TestCase
             });
 
         $this->artisan('sync:github:interactions')
-            ->assertExitCode(0)
+            ->assertExitCode(1)
             ->expectsOutputToContain('Page 2 failed: GitHub GraphQL API error')
             ->expectsOutputToContain('GraphQL error: Could not resolve to a Repository');
     }

--- a/tests/Feature/Console/Commands/SyncGitHubIssuesTest.php
+++ b/tests/Feature/Console/Commands/SyncGitHubIssuesTest.php
@@ -86,7 +86,7 @@ class SyncGitHubIssuesTest extends TestCase
             ->expectsOutputToContain('Done syncing issues.');
     }
 
-    public function testPageErrorShowsErrorMessageAndSuppressesDoneMessage(): void
+    public function testPageErrorExitsWithCode1AndSuppressesDoneMessage(): void
     {
         $this->mock(GitHubIssueService::class);
         $this->mock(OpenSearchService::class);
@@ -107,7 +107,7 @@ class SyncGitHubIssuesTest extends TestCase
             });
 
         $this->artisan('sync:github:issues')
-            ->assertExitCode(0)
+            ->assertExitCode(1)
             ->expectsOutputToContain('Page 3 failed: Connection refused')
             ->doesntExpectOutputToContain('Done syncing issues.');
     }
@@ -135,7 +135,7 @@ class SyncGitHubIssuesTest extends TestCase
             });
 
         $this->artisan('sync:github:issues')
-            ->assertExitCode(0)
+            ->assertExitCode(1)
             ->expectsOutputToContain('Page 2 failed: GitHub GraphQL API error')
             ->expectsOutputToContain('GraphQL error: Could not resolve to a Repository');
     }

--- a/tests/Feature/Console/Commands/SyncGitHubPRsTest.php
+++ b/tests/Feature/Console/Commands/SyncGitHubPRsTest.php
@@ -86,7 +86,7 @@ class SyncGitHubPRsTest extends TestCase
             ->expectsOutputToContain('Done syncing PRs.');
     }
 
-    public function testPageErrorShowsErrorMessageAndSuppressesDoneMessage(): void
+    public function testPageErrorExitsWithCode1AndSuppressesDoneMessage(): void
     {
         $this->mock(GitHubPullRequestService::class);
         $this->mock(OpenSearchService::class);
@@ -107,7 +107,7 @@ class SyncGitHubPRsTest extends TestCase
             });
 
         $this->artisan('sync:github:prs')
-            ->assertExitCode(0)
+            ->assertExitCode(1)
             ->expectsOutputToContain('Page 3 failed: Connection refused')
             ->doesntExpectOutputToContain('Done syncing PRs.');
     }
@@ -135,7 +135,7 @@ class SyncGitHubPRsTest extends TestCase
             });
 
         $this->artisan('sync:github:prs')
-            ->assertExitCode(0)
+            ->assertExitCode(1)
             ->expectsOutputToContain('Page 2 failed: GitHub GraphQL API error')
             ->expectsOutputToContain('GraphQL error: Could not resolve to a Repository');
     }


### PR DESCRIPTION
production leaderboard initialization

Introduces `scripts/bootstrap-prod.sh` to populate OpenSearch with full GitHub history and compute initial leaderboard scores. Script syncs GitHub teams, issues, PRs, interactions, events, and profiles, then runs score computation. Supports optional `SINCE` environment variable to limit history window and reduce GitHub API load. Auto-detects execution context (DDEV container, DDEV host, or plain server) for appropriate artisan invocation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a one-time production bootstrap script that repopulates the search index from GitHub data and computes leaderboard scores.
  * Optionally supports a date window for syncing, and reliably selects the correct runtime for running commands.
* **Bug Fixes**
  * Updated GitHub sync console commands to exit with a non-zero code when sync errors occur, so failures are reflected in automation and monitoring.
* **Tests**
  * Adjusted console-command tests to verify the new failure exit codes behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->